### PR TITLE
Goethe bootstrapping detects correct jar paths

### DIFF
--- a/changelog/@unreleased/pr-93.v2.yml
+++ b/changelog/@unreleased/pr-93.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Goethe bootstrapping detects correct jar paths
+  links:
+  - https://github.com/palantir/goethe/pull/93

--- a/goethe/build.gradle
+++ b/goethe/build.gradle
@@ -23,3 +23,10 @@ moduleJvmArgs {
             'jdk.compiler/com.sun.tools.javac.code',
             'jdk.compiler/com.sun.tools.javac.api'
 }
+
+// Use the shadow-jar to test goethe, otherwise bootstrapping works entirely different from 'prod'
+tasks.withType(Test).configureEach({ test ->
+    Task shadowJar = tasks.shadowJar
+    test.dependsOn(shadowJar)
+    test.setClasspath(shadowJar.outputs.files.plus(test.getClasspath()))
+})

--- a/goethe/src/main/java/com/palantir/goethe/BootstrappingFormatterFacade.java
+++ b/goethe/src/main/java/com/palantir/goethe/BootstrappingFormatterFacade.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
 /** A {@link FormatterFacade} implementation which spawns new java processes with {@link #EXPORTS} applied. */
@@ -47,7 +48,7 @@ final class BootstrappingFormatterFacade implements FormatterFacade {
                             .addAll(EXPORTS)
                             .add( // Classpath
                                     "-cp",
-                                    System.getProperty("java.class.path"),
+                                    getClasspath(),
                                     // Main class
                                     GoetheMain.class.getName(),
                                     // Args
@@ -86,5 +87,21 @@ final class BootstrappingFormatterFacade implements FormatterFacade {
             }
         }
         return baos.toString(StandardCharsets.UTF_8);
+    }
+
+    private static String getClasspath() {
+        return getPath(Goethe.class);
+    }
+
+    private static String getPath(Class<?> clazz) {
+        try {
+            return new File(clazz.getProtectionDomain()
+                            .getCodeSource()
+                            .getLocation()
+                            .toURI())
+                    .getAbsolutePath();
+        } catch (URISyntaxException e) {
+            throw new GoetheException("Failed to locate the jar providing " + clazz, e);
+        }
     }
 }

--- a/goethe/src/main/java/com/palantir/goethe/FormatterFacadeFactory.java
+++ b/goethe/src/main/java/com/palantir/goethe/FormatterFacadeFactory.java
@@ -17,8 +17,8 @@
 package com.palantir.goethe;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import java.lang.management.ManagementFactory;
+import java.util.List;
 
 final class FormatterFacadeFactory {
     private FormatterFacadeFactory() {}
@@ -31,14 +31,14 @@ final class FormatterFacadeFactory {
     }
 
     private static boolean currentJvmHasExportArgs() {
-        ImmutableList<String> arguments =
-                ImmutableList.copyOf(ManagementFactory.getRuntimeMXBean().getInputArguments());
+        List<String> arguments =
+                List.copyOf(ManagementFactory.getRuntimeMXBean().getInputArguments());
         return BootstrappingFormatterFacade.REQUIRED_EXPORTS.stream()
                 .allMatch(required -> hasExport(arguments, required));
     }
 
     @VisibleForTesting
-    static boolean hasExport(ImmutableList<String> arguments, String moduleAndPackage) {
+    static boolean hasExport(List<String> arguments, String moduleAndPackage) {
         String singleArgAddExport = "--add-exports=" + moduleAndPackage + "=ALL-UNNAMED";
         String multiArgAddExport = moduleAndPackage + "=ALL-UNNAMED";
         for (int i = 0; i < arguments.size(); i++) {

--- a/goethe/src/test/java/com/palantir/goethe/GoetheBootstrapTest.java
+++ b/goethe/src/test/java/com/palantir/goethe/GoetheBootstrapTest.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.goethe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.TypeSpec;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class GoetheBootstrapTest {
+
+    @TempDir
+    Path tempDir;
+
+    static Stream<FormatterFacade> formatterFacades() {
+        return Stream.of(new DirectFormatterFacade(), new BootstrappingFormatterFacade());
+    }
+
+    private static String format(FormatterFacade facade, JavaFile javaFile) {
+        return facade.formatSource(javaFile.packageName + '.' + javaFile.typeSpec.name, javaFile.toString());
+    }
+
+    @ParameterizedTest
+    @MethodSource("formatterFacades")
+    public void testDiagnosticException(FormatterFacade formatter) {
+        JavaFile javaFile = JavaFile.builder(
+                        "com.palantir.foo",
+                        TypeSpec.classBuilder("Foo")
+                                .addStaticBlock(CodeBlock.builder()
+                                        .addStatement("type oops name = bar")
+                                        .build())
+                                .build())
+                .build();
+
+        assertThatThrownBy(() -> format(formatter, javaFile))
+                .isInstanceOf(GoetheException.class)
+                .hasMessageContaining("Failed to format 'com.palantir.foo.Foo'")
+                .hasMessageContaining("';' expected")
+                .hasMessageContaining(
+                        "" // newline to align the output
+                                + "    type oops name = bar;\n"
+                                + "            ^");
+    }
+
+    @ParameterizedTest
+    @MethodSource("formatterFacades")
+    public void testFormatting(FormatterFacade formatter) {
+        String padding = "a".repeat(90);
+        JavaFile javaFile = JavaFile.builder(
+                        "com.palantir.foo",
+                        TypeSpec.classBuilder("Foo")
+                                .addStaticBlock(CodeBlock.builder()
+                                        .addStatement("$T.out.println($S)", System.class, padding)
+                                        .build())
+                                .build())
+                .build();
+        String raw = javaFile.toString();
+        String formatted = format(formatter, javaFile);
+        assertThat(formatted)
+                .as("Expected the formatted output to differ from original")
+                .isNotEqualTo(raw)
+                .as("Formatting does not match the expected output, the expectation may need to be updated")
+                .isEqualTo("package com.palantir.foo;\n\n"
+                        + "import java.lang.System;\n"
+                        + "\n"
+                        + "class Foo {\n"
+                        + "    static {\n"
+                        + "        System.out.println(\n"
+                        + "                \"" + padding + "\");\n"
+                        + "    }\n"
+                        + "}\n");
+    }
+}


### PR DESCRIPTION
Previously the detected classpath was detected at the wrong
point, and may not have included the gradle plugin which was
actually using goethe.