### PR TITLE
Limit number of parallel formatting processes

### DIFF
--- a/changelog/@unreleased/pr-161.v2.yml
+++ b/changelog/@unreleased/pr-161.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Limit number of parallel formatting processes when running in JVM >=
+    16.
+  links:
+  - https://github.com/palantir/goethe/pull/161


### PR DESCRIPTION
Currently running conjure compilation freezes up the system completely. This seems to due to a combination of the number of processes that get run & internal tooling to monitor process syscalls. E.g. running `ps aux | grep GoetheMain | wc -l` takes a few minutes to run (returning numbers in the 200-400 range).

In one large internal project my computer ends up crashing after ~12 minutes before finishing compilation. The only solution right now is to use a JVM version before 16.

With this PR, the compilation finishes without issue and is still CPU-bound.