### PR TITLE
Enable autorelease */14 days

### DIFF
--- a/.palantir/autorelease.yml
+++ b/.palantir/autorelease.yml
@@ -1,0 +1,4 @@
+version: 3
+schedules:
+  timer:
+    time_since_last_release: 14 days


### PR DESCRIPTION
This repo hasn't [released in half a year](https://github.com/palantir/goethe/releases), and there's a version bump of palantir-java-format that I'd like to pick up.

Instead of requesting a single manual release, seems better to enable autoreleases so the bots can do this for us.