### PR TITLE
Mark methods using squareup javapoet as deprecated

### DIFF
--- a/changelog/@unreleased/pr-559.v2.yml
+++ b/changelog/@unreleased/pr-559.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Mark methods using squareup javapoet as deprecated
+  links:
+  - https://github.com/palantir/goethe/pull/559

--- a/goethe/src/main/java/com/palantir/goethe/Goethe.java
+++ b/goethe/src/main/java/com/palantir/goethe/Goethe.java
@@ -61,7 +61,9 @@ public final class Goethe {
      *
      * @param file Javapoet file to format
      * @return Formatted source code
+     * @deprecated Use {@link #formatAsString(com.palantir.javapoet.JavaFile)} instead.
      */
+    @Deprecated
     public static String formatAsString(com.squareup.javapoet.JavaFile file) {
         StringBuilder rawSource = new StringBuilder();
         try {
@@ -110,7 +112,9 @@ public final class Goethe {
      *
      * @param file Javapoet file to format
      * @param filer Destination for the formatted file
+     * @deprecated Use {@link #formatAndEmit(com.palantir.javapoet.JavaFile, Filer)} instead.
      */
+    @Deprecated
     public static void formatAndEmit(com.squareup.javapoet.JavaFile file, Filer filer) {
         String formatted = formatAsString(file);
 
@@ -160,7 +164,9 @@ public final class Goethe {
      * @param file Javapoet file to format
      * @param baseDir Source set root where the formatted file will be written
      * @return the new file location
+     * @deprecated Use {@link #formatAndEmit(com.palantir.javapoet.JavaFile, Path)} instead.
      */
+    @Deprecated
     public static Path formatAndEmit(com.squareup.javapoet.JavaFile file, Path baseDir) {
         String formatted = formatAsString(file);
         try {


### PR DESCRIPTION
The original square/javapoet project has been marked [deprecated](https://github.com/square/javapoet?tab=readme-ov-file#deprecated) for 4 years now, and there's a successor at https://github.com/palantir/javapoet that is actively maintained.

In https://github.com/palantir/goethe/pull/472 this project started supporting both versions (they are at non-conflicting coordinates).  It's now been 6 months and the new version of Goethe has trickled through the ecosystem.

With this change, we mark the old square versions as deprecated, and declare this project's intention to eventually remove them.  An example PR that does remove them is at https://github.com/palantir/goethe/pull/558 but I think we need a bit more time internally to remove these references before pulling the plug.

And even if there is little benefit to pulling the plug, I think the deprecation warning is important. This makes it clear to new callers who see multiple method overloads which one they should be using. One reason is that the old square release contains a perf issue with an unreleased fix: `https://github.com/square/javapoet/pull/828` that is released on the Palantir successor.