### PR TITLE
Support formatting string values as well as javapoet

### DIFF
--- a/changelog/@unreleased/pr-651.v2.yml
+++ b/changelog/@unreleased/pr-651.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Support formatting string values as well as javapoet
+  links:
+  - https://github.com/palantir/goethe/pull/651

--- a/goethe/src/main/java/com/palantir/goethe/Goethe.java
+++ b/goethe/src/main/java/com/palantir/goethe/Goethe.java
@@ -16,7 +16,7 @@
 
 package com.palantir.goethe;
 
-import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
@@ -234,16 +234,23 @@ public final class Goethe {
      * e.g., {@code com.foo.bar.MyClass -> /<baseDir>/com/foo/bar/MyClass.java} and creates all directories.
      */
     private static Path getFilePath(Path baseDir, String packageName, String typeName) throws IOException {
-        String fullyQualifiedTypeName = packageName.isEmpty() ? typeName : packageName + '.' + typeName;
-        return getFilePath(baseDir, fullyQualifiedTypeName);
+        Path outputFile = baseDir;
+        for (String component : Splitter.on('.').split(packageName)) {
+            outputFile = outputFile.resolve(component);
+        }
+        outputFile = outputFile.resolve(typeName + ".java");
+
+        Files.createDirectories(outputFile.getParent());
+        return outputFile;
     }
 
-    private static Path getFilePath(Path baseDir, String fullyQualifiedTypeName) throws IOException {
-        Preconditions.checkArgument(
-                Files.notExists(baseDir) || Files.isDirectory(baseDir),
-                "path %s exists but is not a directory.",
-                baseDir);
-        Path outputFile = baseDir.resolve(fullyQualifiedTypeName.replace('.', '/') + ".java");
+    private static Path getFilePath(Path baseDir, String className) throws IOException {
+        Path outputFile = baseDir;
+        for (String component : Splitter.on('.').split(className)) {
+            outputFile = outputFile.resolve(component);
+        }
+        outputFile = outputFile.resolveSibling(outputFile.getFileName() + ".java");
+
         Files.createDirectories(outputFile.getParent());
         return outputFile;
     }

--- a/goethe/src/main/java/com/palantir/goethe/Goethe.java
+++ b/goethe/src/main/java/com/palantir/goethe/Goethe.java
@@ -73,6 +73,17 @@ public final class Goethe {
     }
 
     /**
+     * Format a {@link String} containing a full java file, and return the result as a {@link String}.
+     *
+     * @param className The class name of the java file, including package, eg {@code com.palantir.goethe.Goethe}
+     * @param source The java source code to format
+     * @return The formatted source code
+     */
+    public static String formatAsString(String className, String source) {
+        return JAVA_FORMATTER.formatSource(className, source);
+    }
+
+    /**
      * Format a {@link com.palantir.javapoet.JavaFile javapoet java file} and write the result to an {@link Filer annotation processing
      * filer}.
      *
@@ -136,6 +147,34 @@ public final class Goethe {
     }
 
     /**
+     * Format a {@link String} containing a full java file, and write the result to an {@link Filer annotation
+     * processing filer}.
+     *
+     * @param className The class name of the java file, including package, eg {@code com.palantir.goethe.Goethe}
+     * @param source The java source code to format
+     */
+    public static void formatAndEmit(String className, String source, Filer filer) {
+        String formatted = formatAsString(className, source);
+
+        JavaFileObject filerSourceFile = null;
+        try {
+            filerSourceFile = filer.createSourceFile(className);
+            try (Writer writer = filerSourceFile.openWriter()) {
+                writer.write(formatted);
+            }
+        } catch (IOException e) {
+            if (filerSourceFile != null) {
+                try {
+                    filerSourceFile.delete();
+                } catch (Exception deletionFailure) {
+                    e.addSuppressed(deletionFailure);
+                }
+            }
+            throw new GoetheException("Failed to write formatted code to the filer", e);
+        }
+    }
+
+    /**
      * Formats the given Java file and emits it to the appropriate directory under {@code baseDir}.
      *
      * @param file Javapoet file to format
@@ -165,6 +204,34 @@ public final class Goethe {
         String formatted = formatAsString(file);
         try {
             Path output = getFilePath(baseDir, file.packageName, file.typeSpec.name);
+            Files.writeString(output, formatted);
+            return output;
+        } catch (IOException e) {
+            throw new GoetheException("Failed to write formatted sources", e);
+        }
+    }
+
+    /**
+     * Formats the given Java file and emits it to the appropriate directory under {@code baseDir}.
+     *
+     * @param fullClassName The class name of the java file, including package, eg {@code com.palantir.goethe.Goethe}
+     * @param source The java source code to format
+     * @param baseDir Source set root where the formatted file will be written
+     * @return the new file location
+     */
+    public static Path formatAndEmit(String fullClassName, String source, Path baseDir) {
+        String formatted = formatAsString(fullClassName, source);
+        try {
+            String packageName;
+            String className;
+            if (fullClassName.contains(".")) {
+                packageName = fullClassName.substring(0, fullClassName.lastIndexOf('.'));
+                className = fullClassName.substring(fullClassName.lastIndexOf('.') + 1);
+            } else {
+                packageName = "";
+                className = fullClassName;
+            }
+            Path output = getFilePath(baseDir, packageName, className);
             Files.writeString(output, formatted);
             return output;
         } catch (IOException e) {

--- a/goethe/src/main/java/com/palantir/goethe/Goethe.java
+++ b/goethe/src/main/java/com/palantir/goethe/Goethe.java
@@ -17,7 +17,6 @@
 package com.palantir.goethe;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
@@ -75,7 +74,7 @@ public final class Goethe {
     /**
      * Format a {@link String} containing a full java file, and return the result as a {@link String}.
      *
-     * @param className The class name of the java file, including package, eg {@code com.palantir.goethe.Goethe}
+     * @param className The fully qualified class name of the java file, eg. {@code com.palantir.goethe.Goethe}
      * @param source The java source code to format
      * @return The formatted source code
      */
@@ -150,7 +149,7 @@ public final class Goethe {
      * Format a {@link String} containing a full java file, and write the result to an {@link Filer annotation
      * processing filer}.
      *
-     * @param className The class name of the java file, including package, eg {@code com.palantir.goethe.Goethe}
+     * @param className The fully qualified class name of the java file, eg. {@code com.palantir.goethe.Goethe}
      * @param source The java source code to format
      */
     public static void formatAndEmit(String className, String source, Filer filer) {
@@ -214,24 +213,15 @@ public final class Goethe {
     /**
      * Formats the given Java file and emits it to the appropriate directory under {@code baseDir}.
      *
-     * @param fullClassName The class name of the java file, including package, eg {@code com.palantir.goethe.Goethe}
+     * @param className The class name of the java file, including package, eg {@code com.palantir.goethe.Goethe}
      * @param source The java source code to format
      * @param baseDir Source set root where the formatted file will be written
      * @return the new file location
      */
-    public static Path formatAndEmit(String fullClassName, String source, Path baseDir) {
-        String formatted = formatAsString(fullClassName, source);
+    public static Path formatAndEmit(String className, String source, Path baseDir) {
+        String formatted = formatAsString(className, source);
         try {
-            String packageName;
-            String className;
-            if (fullClassName.contains(".")) {
-                packageName = fullClassName.substring(0, fullClassName.lastIndexOf('.'));
-                className = fullClassName.substring(fullClassName.lastIndexOf('.') + 1);
-            } else {
-                packageName = "";
-                className = fullClassName;
-            }
-            Path output = getFilePath(baseDir, packageName, className);
+            Path output = getFilePath(baseDir, className);
             Files.writeString(output, formatted);
             return output;
         } catch (IOException e) {
@@ -244,19 +234,18 @@ public final class Goethe {
      * e.g., {@code com.foo.bar.MyClass -> /<baseDir>/com/foo/bar/MyClass.java} and creates all directories.
      */
     private static Path getFilePath(Path baseDir, String packageName, String typeName) throws IOException {
+        String fullyQualifiedTypeName = packageName.isEmpty() ? typeName : packageName + '.' + typeName;
+        return getFilePath(baseDir, fullyQualifiedTypeName);
+    }
+
+    private static Path getFilePath(Path baseDir, String fullyQualifiedTypeName) throws IOException {
         Preconditions.checkArgument(
                 Files.notExists(baseDir) || Files.isDirectory(baseDir),
                 "path %s exists but is not a directory.",
                 baseDir);
-        Path outputDirectory = baseDir;
-        if (!packageName.isEmpty()) {
-            for (String packageComponent : Splitter.on(".").split(packageName)) {
-                outputDirectory = outputDirectory.resolve(packageComponent);
-            }
-            Files.createDirectories(outputDirectory);
-        }
-
-        return outputDirectory.resolve(typeName + ".java");
+        Path outputFile = baseDir.resolve(fullyQualifiedTypeName.replace('.', '/') + ".java");
+        Files.createDirectories(outputFile.getParent());
+        return outputFile;
     }
 
     private Goethe() {}

--- a/goethe/src/test/java/com/palantir/goethe/GoetheStringTest.java
+++ b/goethe/src/test/java/com/palantir/goethe/GoetheStringTest.java
@@ -1,0 +1,116 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.goethe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import javax.annotation.processing.Filer;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+class GoetheStringTest {
+
+    private static final String CLASS_NAME = "com.palantir.foo.Foo";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void testDiagnosticException() {
+        String source = unformattedClassWithCode("  type oops name = bar;");
+        assertThatThrownBy(() -> Goethe.formatAsString(CLASS_NAME, source))
+                .isInstanceOf(GoetheException.class)
+                .hasMessageContaining("Failed to format 'com.palantir.foo.Foo'")
+                .hasMessageContaining("';' expected")
+                .hasMessageContaining(
+                        "" // newline to align the output
+                                + "  type oops name = bar;\n"
+                                + "          ^");
+    }
+
+    @Test
+    public void testFormatting() {
+        String padding = "a".repeat(90);
+        String source = unformattedClassWithCode("System.out.println(\"" + padding + "\");");
+        String formatted = Goethe.formatAsString(CLASS_NAME, source);
+        assertThat(formatted)
+                .as("Expected the formatted output to differ from original")
+                .isNotEqualTo(source)
+                .as("Formatting does not match the expected output, the expectation may need to be updated")
+                .isEqualTo("package com.palantir.foo;\n\n"
+                        + "import java.lang.System;\n"
+                        + "\n"
+                        + "class Foo {\n"
+                        + "    static {\n"
+                        + "        System.out.println(\n"
+                        + "                \"" + padding + "\");\n"
+                        + "    }\n"
+                        + "}\n");
+    }
+
+    @Test
+    public void testFormattingToFiler() throws IOException {
+        String padding = "a".repeat(90);
+        String source = unformattedClassWithCode("System.out.println(\"" + padding + "\");");
+        StringWriter writer = new StringWriter();
+        JavaFileObject javaFileObject = Mockito.mock(JavaFileObject.class);
+        when(javaFileObject.openWriter()).thenReturn(writer);
+        Filer filer = Mockito.mock(Filer.class);
+        // If the originating elements aren't passed through to the Filer, this test will fail with:
+        // 'Cannot invoke "javax.tools.JavaFileObject.openWriter()" because "filerSourceFile" is null'
+        when(filer.createSourceFile(eq(CLASS_NAME))).thenReturn(javaFileObject);
+        Goethe.formatAndEmit(CLASS_NAME, source, filer);
+        assertThat(writer.toString())
+                .as("Expected the formatted output to differ from original")
+                .isNotEqualTo(source)
+                .as("Expected identical output to 'formatAsString'")
+                .isEqualTo(Goethe.formatAsString(CLASS_NAME, source));
+    }
+
+    @Test
+    public void testFormattingToDirectory() {
+        String padding = "a".repeat(90);
+        String source = unformattedClassWithCode("System.out.println(\"" + padding + "\");");
+        Path location = Goethe.formatAndEmit(CLASS_NAME, source, tempDir);
+        assertThat(location.toString()).endsWith("com/palantir/foo/Foo.java");
+        assertThat(location)
+                .as("Expected contents on disk to be formatted")
+                .hasContent(Goethe.formatAsString(CLASS_NAME, source));
+    }
+
+    private static String unformattedClassWithCode(String code) {
+        StringBuilder builder = new StringBuilder()
+                .append("package com.palantir.foo;")
+                .append("import java.lang.System;")
+                .append("class Foo {")
+                .append("    static {")
+                .append("\n")
+                .append(code)
+                .append("\n")
+                .append("    }")
+                .append("}");
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
For some legacy code generation tooling, we aren't using javapoet, but it would still be nice if the generated code could be formatted by Goethe to make it more readable. Goethe operates on strings internally anyway, so exposing it publicly seems fine.