### PR TITLE
Emit warning to stderr for slow formatting fallback

### DIFF
--- a/changelog/@unreleased/pr-737.v2.yml
+++ b/changelog/@unreleased/pr-737.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Emit warning to stderr for slow formatting fallback
+  links:
+  - https://github.com/palantir/goethe/pull/737

--- a/goethe/src/main/java/com/palantir/goethe/FormatterFacadeFactory.java
+++ b/goethe/src/main/java/com/palantir/goethe/FormatterFacadeFactory.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.lang.management.ManagementFactory;
 import java.util.List;
 
+@SuppressWarnings("checkstyle:BanSystemErr") // this repo doesn't use safe-logging
 final class FormatterFacadeFactory {
     private FormatterFacadeFactory() {}
 
@@ -27,6 +28,9 @@ final class FormatterFacadeFactory {
         if (currentJvmHasExportArgs()) {
             return new DirectFormatterFacade();
         }
+        System.err.println("[goethe] The current JVM does not have the right JVM arguments for direct formatting. "
+                + "Falling back to equivalent but slower bootstrapping formatter. Required exports: "
+                + BootstrappingFormatterFacade.REQUIRED_EXPORTS);
         return new BootstrappingFormatterFacade();
     }
 


### PR DESCRIPTION
## Before this PR

On an internal repo we have a gradle task that does codegen and formats the generated code using Goethe.  On a recent run that task took 3m57s, but after adding these flags to the `JavaExec` task it now runs in 6.9s!  See internal `eddie/pull/30163` and `eddie/pull/30153`

```
    jvmArgs = [
            '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED',
            '--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED',
            '--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED',
            '--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED',
            '--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED'
    ]
```

The reason is that without these flags goethe launches a new JVM for every file being formatted, and with the flags it runs within the same JVM.  This fallback happens in `FormatterFacadeFactory.create()`

Unfortunately we've been living with the slowness for years, and there may be other repos as well.  Internal search for `-r:goethe Goethe.formatAndEmit(` shows about ~30 repos using Goethe which may benefit from running with these flags.

## After this PR

With this change, we'll now emit a warning to stderr when this fallback path is taken.  I'm hoping this will be noticed 

## Alternatives

Alternatively, adding some kind of `requireFastPathOrFail: true` option that could be set on `Goethe.formatAndEmit()` might be better, but would require callers to migrate.

## Possible Downsides
I'm not sure if stderr will be typically viewable by humans or noticeable enough here to make a difference.